### PR TITLE
Add CocoaPods support

### DIFF
--- a/Advance.podspec
+++ b/Advance.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
 
   s.license      = "BSD 2-clause \"Simplified\" License"
 
-  s.author       = "Tim Donnelly"
-  s.social_media_url = 'http://twitter.com/tdonnelly'
+  s.author       = "Storehouse", "Tim Donnelly"
+  s.social_media_url = 'http://twitter.com/storehousehq'
 
   s.source       = { :git => "https://github.com/storehouse/Advance.git", :tag => "0.9" }
 

--- a/Advance.podspec
+++ b/Advance.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "Advance"
+  s.version      = "0.9"
+  s.summary      = "A powerful animation framework for iOS."
+  s.description  = "Advance is a pure Swift framework that enables advanced animations and physics-based interactions."
+
+  s.homepage     = "https://github.com/storehouse/Advance"
+
+  s.license      = "BSD 2-clause \"Simplified\" License"
+
+  s.author       = "Tim Donnelly"
+  s.social_media_url = 'http://twitter.com/tdonnelly'
+
+  s.source       = { :git => "https://github.com/storehouse/Advance.git", :tag => "0.9" }
+
+  s.source_files = "Advance/**/*.swift"
+
+  s.ios.deployment_target = "8.0"
+end


### PR DESCRIPTION
Hey, this pull request would close #2 
- [x] create podspec
- [x] podspec passes lint

``` shell
dkhamsing$ pod --version
0.39.0

dkhamsing$ pod spec lint Advance.podspec 

 -> Advance (0.9)

Analyzed 1 podspec.

Advance.podspec passed validation.
```
- [x] integrate in simple demo https://github.com/dkhamsing/Advance/tree/cocoapods-demo/Cocoapods-demo
- [x] get setup with CocoaPods Trunk service (to publish/make it public) @timdonnelly  https://guides.cocoapods.org/making/getting-setup-with-trunk.html
- [x] update readme @timdonnelly  

To install using [CocoaPods](https://cocoapods.org/), add the following to your Podfile:

``` ruby
pod 'Advance', '~> 0.9'
```
