### PR TITLE
Fix smart quotes in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,3 @@
 import PackageDescription
 
-let package = Package(name: “Advance”)
+let package = Package(name: "Advance")


### PR DESCRIPTION
Replace smart, curly quotes with regular, string-delimiting quotes.
