### PR TITLE
Fixed typo in the Dynamics playground page

### DIFF
--- a/Playground.playground/Pages/Dynamics.xcplaygroundpage/Contents.swift
+++ b/Playground.playground/Pages/Dynamics.xcplaygroundpage/Contents.swift
@@ -6,7 +6,7 @@ import Advance
 
 
 var f = SpringFunction(target: 0.0)
-var sim = DynamicSimulation(function: f, value: 0.0)
+var sim = DynamicSolver(function: f, value: 0.0)
 
 sim.velocity = 800.0
 


### PR DESCRIPTION
The `DynamicSimulation` is renamed with `DynamicSolver`.
