### PR TITLE
Renamed protocols to remove `...Type` suffix

### DIFF
--- a/Advance.xcodeproj/project.pbxproj
+++ b/Advance.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		2212A2F11C82702500BB79F4 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2212A2F01C82702500BB79F4 /* ActivityView.swift */; };
 		22142E651C810D86000C6DEB /* ActivityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22142E641C810D86000C6DEB /* ActivityViewController.swift */; };
 		22142E671C810DA7000C6DEB /* GravityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22142E661C810DA7000C6DEB /* GravityViewController.swift */; };
-		22168B5B1C7A547300BAE519 /* VectorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTypeTests.swift */; };
+		22168B5B1C7A547300BAE519 /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTests.swift */; };
 		22168B5D1C7A5E3500BAE519 /* BasicAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5C1C7A5E3500BAE519 /* BasicAnimationTests.swift */; };
 		222E211D1C7D4C300063FAA2 /* SimpleTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E211C1C7D4C300063FAA2 /* SimpleTransform.swift */; };
 		222E211F1C7D8CF00063FAA2 /* SpringConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E211E1C7D8CF00063FAA2 /* SpringConfigurationView.swift */; };
@@ -43,7 +43,7 @@
 		228E20541C9CB99D0058ADA1 /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		228E20551C9CB99D0058ADA1 /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
 		228E20561C9CB99D0058ADA1 /* DecayFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */; };
-		228E20571C9CB99D0058ADA1 /* VectorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* VectorType.swift */; };
+		228E20571C9CB99D0058ADA1 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* Vector.swift */; };
 		228E20581C9CB99D0058ADA1 /* Double+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4871C876AD1000CF9EE /* Double+VectorConvertible.swift */; };
 		228E20591C9CB99D0058ADA1 /* AnyValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */; };
 		228E205A1C9CB99D0058ADA1 /* CGRect+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4841C876AD1000CF9EE /* CGRect+VectorConvertible.swift */; };
@@ -60,7 +60,7 @@
 		228E20731C9CB9B00058ADA1 /* CAMediaTimingFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4C1C8112810039B9BB /* CAMediaTimingFunctionTests.swift */; };
 		228E20741C9CB9B00058ADA1 /* UnitBezierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4A1C80E2700039B9BB /* UnitBezierTests.swift */; };
 		228E20751C9CB9B00058ADA1 /* DisplayLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE959E81C9388B9008487A8 /* DisplayLinkTests.swift */; };
-		228E20761C9CB9B00058ADA1 /* VectorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTypeTests.swift */; };
+		228E20761C9CB9B00058ADA1 /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTests.swift */; };
 		228E20771C9CB9B00058ADA1 /* BasicAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5C1C7A5E3500BAE519 /* BasicAnimationTests.swift */; };
 		228E20781C9CB9B00058ADA1 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4E1C8114680039B9BB /* EventTests.swift */; };
 		228E20791C9CB9B00058ADA1 /* VectorConvenienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F471C80DAA00039B9BB /* VectorConvenienceTests.swift */; };
@@ -113,7 +113,7 @@
 		5D3A2F561C920CCA0071F08F /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48D1C876AD1000CF9EE /* Vector3.swift */; };
 		5D3A2F571C920CCA0071F08F /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48E1C876AD1000CF9EE /* Vector4.swift */; };
 		5D3A2F581C920CCA0071F08F /* VectorMathCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48F1C876AD1000CF9EE /* VectorMathCapable.swift */; };
-		5D3A2F591C920CCA0071F08F /* VectorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* VectorType.swift */; };
+		5D3A2F591C920CCA0071F08F /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* Vector.swift */; };
 		5D3A2F5A1C920CCA0071F08F /* Interpolatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48A1C876AD1000CF9EE /* Interpolatable.swift */; };
 		5D3A2F5F1C922DAA0071F08F /* DisplayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3A2F5E1C922DAA0071F08F /* DisplayLink.swift */; };
 		5D3A2F631C923ADB0071F08F /* DisplayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3A2F5E1C922DAA0071F08F /* DisplayLink.swift */; };
@@ -159,11 +159,11 @@
 		5DB1A4B01C876AD1000CF9EE /* Vector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48D1C876AD1000CF9EE /* Vector3.swift */; };
 		5DB1A4B11C876AD1000CF9EE /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48E1C876AD1000CF9EE /* Vector4.swift */; };
 		5DB1A4B21C876AD1000CF9EE /* VectorMathCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48F1C876AD1000CF9EE /* VectorMathCapable.swift */; };
-		5DB1A4B31C876AD1000CF9EE /* VectorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* VectorType.swift */; };
+		5DB1A4B31C876AD1000CF9EE /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4901C876AD1000CF9EE /* Vector.swift */; };
 		5DE959E91C9388B9008487A8 /* DisplayLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE959E81C9388B9008487A8 /* DisplayLinkTests.swift */; };
 		5DE959F51C9392E1008487A8 /* Advance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D3A2F311C9209EE0071F08F /* Advance.framework */; };
 		5DE959FC1C93940E008487A8 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4E1C8114680039B9BB /* EventTests.swift */; };
-		5DE959FD1C93940E008487A8 /* VectorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTypeTests.swift */; };
+		5DE959FD1C93940E008487A8 /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5A1C7A547300BAE519 /* VectorTests.swift */; };
 		5DE959FE1C93940E008487A8 /* VectorConvenienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F471C80DAA00039B9BB /* VectorConvenienceTests.swift */; };
 		5DE959FF1C93940E008487A8 /* BasicAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22168B5C1C7A5E3500BAE519 /* BasicAnimationTests.swift */; };
 		5DE95A001C93940E008487A8 /* UnitBezierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4A1C80E2700039B9BB /* UnitBezierTests.swift */; };
@@ -283,7 +283,7 @@
 		2212A2F01C82702500BB79F4 /* ActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
 		22142E641C810D86000C6DEB /* ActivityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityViewController.swift; sourceTree = "<group>"; };
 		22142E661C810DA7000C6DEB /* GravityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravityViewController.swift; sourceTree = "<group>"; };
-		22168B5A1C7A547300BAE519 /* VectorTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorTypeTests.swift; sourceTree = "<group>"; };
+		22168B5A1C7A547300BAE519 /* VectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorTests.swift; sourceTree = "<group>"; };
 		22168B5C1C7A5E3500BAE519 /* BasicAnimationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAnimationTests.swift; sourceTree = "<group>"; };
 		222E211C1C7D4C300063FAA2 /* SimpleTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleTransform.swift; sourceTree = "<group>"; };
 		222E211E1C7D8CF00063FAA2 /* SpringConfigurationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringConfigurationView.swift; sourceTree = "<group>"; };
@@ -363,7 +363,7 @@
 		5DB1A48D1C876AD1000CF9EE /* Vector3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector3.swift; sourceTree = "<group>"; };
 		5DB1A48E1C876AD1000CF9EE /* Vector4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector4.swift; sourceTree = "<group>"; };
 		5DB1A48F1C876AD1000CF9EE /* VectorMathCapable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorMathCapable.swift; sourceTree = "<group>"; };
-		5DB1A4901C876AD1000CF9EE /* VectorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorType.swift; sourceTree = "<group>"; };
+		5DB1A4901C876AD1000CF9EE /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
 		5DE959E81C9388B9008487A8 /* DisplayLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayLinkTests.swift; sourceTree = "<group>"; };
 		5DE959F01C9392E1008487A8 /* AdvanceTests-OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AdvanceTests-OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DE959F41C9392E1008487A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -566,7 +566,7 @@
 			isa = PBXGroup;
 			children = (
 				5DA94F4E1C8114680039B9BB /* EventTests.swift */,
-				22168B5A1C7A547300BAE519 /* VectorTypeTests.swift */,
+				22168B5A1C7A547300BAE519 /* VectorTests.swift */,
 				5DA94F471C80DAA00039B9BB /* VectorConvenienceTests.swift */,
 				22168B5C1C7A5E3500BAE519 /* BasicAnimationTests.swift */,
 				5DA94F4A1C80E2700039B9BB /* UnitBezierTests.swift */,
@@ -742,7 +742,7 @@
 				5DB1A48D1C876AD1000CF9EE /* Vector3.swift */,
 				5DB1A48E1C876AD1000CF9EE /* Vector4.swift */,
 				5DB1A48F1C876AD1000CF9EE /* VectorMathCapable.swift */,
-				5DB1A4901C876AD1000CF9EE /* VectorType.swift */,
+				5DB1A4901C876AD1000CF9EE /* Vector.swift */,
 				5DB1A48A1C876AD1000CF9EE /* Interpolatable.swift */,
 			);
 			path = Vectors;
@@ -1127,7 +1127,7 @@
 				228E20541C9CB99D0058ADA1 /* DecayAnimation.swift in Sources */,
 				228E20551C9CB99D0058ADA1 /* SpringAnimation.swift in Sources */,
 				228E20561C9CB99D0058ADA1 /* DecayFunction.swift in Sources */,
-				228E20571C9CB99D0058ADA1 /* VectorType.swift in Sources */,
+				228E20571C9CB99D0058ADA1 /* Vector.swift in Sources */,
 				228E20581C9CB99D0058ADA1 /* Double+VectorConvertible.swift in Sources */,
 				228E20591C9CB99D0058ADA1 /* AnyValueAnimation.swift in Sources */,
 				228E205A1C9CB99D0058ADA1 /* CGRect+VectorConvertible.swift in Sources */,
@@ -1151,7 +1151,7 @@
 				228E20731C9CB9B00058ADA1 /* CAMediaTimingFunctionTests.swift in Sources */,
 				228E20741C9CB9B00058ADA1 /* UnitBezierTests.swift in Sources */,
 				228E20751C9CB9B00058ADA1 /* DisplayLinkTests.swift in Sources */,
-				228E20761C9CB9B00058ADA1 /* VectorTypeTests.swift in Sources */,
+				228E20761C9CB9B00058ADA1 /* VectorTests.swift in Sources */,
 				228E20771C9CB9B00058ADA1 /* BasicAnimationTests.swift in Sources */,
 				228E20781C9CB9B00058ADA1 /* EventTests.swift in Sources */,
 				228E20791C9CB9B00058ADA1 /* VectorConvenienceTests.swift in Sources */,
@@ -1216,7 +1216,7 @@
 				5DB1A4981C876AD1000CF9EE /* DecayAnimation.swift in Sources */,
 				5DB1A4991C876AD1000CF9EE /* SpringAnimation.swift in Sources */,
 				5DB1A4A11C876AD1000CF9EE /* DecayFunction.swift in Sources */,
-				5DB1A4B31C876AD1000CF9EE /* VectorType.swift in Sources */,
+				5DB1A4B31C876AD1000CF9EE /* Vector.swift in Sources */,
 				5DB1A4AB1C876AD1000CF9EE /* Double+VectorConvertible.swift in Sources */,
 				5DB1A4941C876AD1000CF9EE /* AnyValueAnimation.swift in Sources */,
 				5DB1A4A81C876AD1000CF9EE /* CGRect+VectorConvertible.swift in Sources */,
@@ -1240,7 +1240,7 @@
 				5DA94F4D1C8112810039B9BB /* CAMediaTimingFunctionTests.swift in Sources */,
 				5DA94F4B1C80E2700039B9BB /* UnitBezierTests.swift in Sources */,
 				5DE959E91C9388B9008487A8 /* DisplayLinkTests.swift in Sources */,
-				22168B5B1C7A547300BAE519 /* VectorTypeTests.swift in Sources */,
+				22168B5B1C7A547300BAE519 /* VectorTests.swift in Sources */,
 				22168B5D1C7A5E3500BAE519 /* BasicAnimationTests.swift in Sources */,
 				5DA94F4F1C8114680039B9BB /* EventTests.swift in Sources */,
 				5DA94F481C80DAA00039B9BB /* VectorConvenienceTests.swift in Sources */,
@@ -1258,7 +1258,7 @@
 				5D3A2F4C1C920CBC0071F08F /* SpringFunction.swift in Sources */,
 				5D3A2F391C920C710071F08F /* Animatable.swift in Sources */,
 				5D3A2F3A1C920C7C0071F08F /* BasicAnimation.swift in Sources */,
-				5D3A2F591C920CCA0071F08F /* VectorType.swift in Sources */,
+				5D3A2F591C920CCA0071F08F /* Vector.swift in Sources */,
 				5D3A2F3F1C920C8C0071F08F /* Animation.swift in Sources */,
 				5D3A2F4F1C920CC20071F08F /* CGFloat+VectorConvertible.swift in Sources */,
 				5D3A2F531C920CC20071F08F /* CGVector+VectorConvertible.swift in Sources */,
@@ -1308,7 +1308,7 @@
 				5DE95A021C93940E008487A8 /* DisplayLinkTests.swift in Sources */,
 				5DE95A011C93940E008487A8 /* CAMediaTimingFunctionTests.swift in Sources */,
 				5DE959FF1C93940E008487A8 /* BasicAnimationTests.swift in Sources */,
-				5DE959FD1C93940E008487A8 /* VectorTypeTests.swift in Sources */,
+				5DE959FD1C93940E008487A8 /* VectorTests.swift in Sources */,
 				5DE959FC1C93940E008487A8 /* EventTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Advance.xcodeproj/project.pbxproj
+++ b/Advance.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		228E205F1C9CB99D0058ADA1 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4721C876AD1000CF9EE /* Animator.swift */; };
 		228E20601C9CB99D0058ADA1 /* DynamicSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */; };
 		228E20611C9CB99D0058ADA1 /* CGVector+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4861C876AD1000CF9EE /* CGVector+VectorConvertible.swift */; };
-		228E20621C9CB99D0058ADA1 /* TimingFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */; };
+		228E20621C9CB99D0058ADA1 /* TimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunction.swift */; };
 		228E20631C9CB99D0058ADA1 /* CAMediaTimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4771C876AD1000CF9EE /* CAMediaTimingFunction.swift */; };
 		228E20641C9CB99D0058ADA1 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4751C876AD1000CF9EE /* Event.swift */; };
 		228E20731C9CB9B00058ADA1 /* CAMediaTimingFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4C1C8112810039B9BB /* CAMediaTimingFunctionTests.swift */; };
@@ -83,7 +83,7 @@
 		5D39CEEC1C6E983100DFCF86 /* Advance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D39CEE11C6E983100DFCF86 /* Advance.framework */; };
 		5D3A2F391C920C710071F08F /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4631C876AD1000CF9EE /* Animatable.swift */; };
 		5D3A2F3A1C920C7C0071F08F /* BasicAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */; };
-		5D3A2F3B1C920C7C0071F08F /* TimingFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */; };
+		5D3A2F3B1C920C7C0071F08F /* TimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunction.swift */; };
 		5D3A2F3C1C920C7C0071F08F /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */; };
 		5D3A2F3D1C920C810071F08F /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		5D3A2F3E1C920C860071F08F /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
@@ -131,7 +131,7 @@
 		5DB1A4931C876AD1000CF9EE /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* Animation.swift */; };
 		5DB1A4941C876AD1000CF9EE /* AnyValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */; };
 		5DB1A4951C876AD1000CF9EE /* BasicAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */; };
-		5DB1A4961C876AD1000CF9EE /* TimingFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */; };
+		5DB1A4961C876AD1000CF9EE /* TimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunction.swift */; };
 		5DB1A4971C876AD1000CF9EE /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */; };
 		5DB1A4981C876AD1000CF9EE /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		5DB1A4991C876AD1000CF9EE /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
@@ -335,7 +335,7 @@
 		5DB1A4661C876AD1000CF9EE /* Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyValueAnimation.swift; sourceTree = "<group>"; };
 		5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAnimation.swift; sourceTree = "<group>"; };
-		5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimingFunctionType.swift; sourceTree = "<group>"; };
+		5DB1A46A1C876AD1000CF9EE /* TimingFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimingFunction.swift; sourceTree = "<group>"; };
 		5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitBezier.swift; sourceTree = "<group>"; };
 		5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecayAnimation.swift; sourceTree = "<group>"; };
 		5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringAnimation.swift; sourceTree = "<group>"; };
@@ -651,7 +651,7 @@
 			isa = PBXGroup;
 			children = (
 				5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */,
-				5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */,
+				5DB1A46A1C876AD1000CF9EE /* TimingFunction.swift */,
 				5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */,
 			);
 			path = Basic;
@@ -1138,7 +1138,7 @@
 				228E205F1C9CB99D0058ADA1 /* Animator.swift in Sources */,
 				228E20601C9CB99D0058ADA1 /* DynamicSolver.swift in Sources */,
 				228E20611C9CB99D0058ADA1 /* CGVector+VectorConvertible.swift in Sources */,
-				228E20621C9CB99D0058ADA1 /* TimingFunctionType.swift in Sources */,
+				228E20621C9CB99D0058ADA1 /* TimingFunction.swift in Sources */,
 				228E20631C9CB99D0058ADA1 /* CAMediaTimingFunction.swift in Sources */,
 				228E20641C9CB99D0058ADA1 /* Event.swift in Sources */,
 			);
@@ -1227,7 +1227,7 @@
 				5DB1A49B1C876AD1000CF9EE /* Animator.swift in Sources */,
 				5DB1A4A31C876AD1000CF9EE /* DynamicSolver.swift in Sources */,
 				5DB1A4AA1C876AD1000CF9EE /* CGVector+VectorConvertible.swift in Sources */,
-				5DB1A4961C876AD1000CF9EE /* TimingFunctionType.swift in Sources */,
+				5DB1A4961C876AD1000CF9EE /* TimingFunction.swift in Sources */,
 				5DB1A49E1C876AD1000CF9EE /* CAMediaTimingFunction.swift in Sources */,
 				5DB1A49D1C876AD1000CF9EE /* Event.swift in Sources */,
 			);
@@ -1272,7 +1272,7 @@
 				5D3A2F4E1C920CC20071F08F /* Double+VectorConvertible.swift in Sources */,
 				5D3A2F3D1C920C810071F08F /* DecayAnimation.swift in Sources */,
 				5D3A2F481C920CBC0071F08F /* DecayFunction.swift in Sources */,
-				5D3A2F3B1C920C7C0071F08F /* TimingFunctionType.swift in Sources */,
+				5D3A2F3B1C920C7C0071F08F /* TimingFunction.swift in Sources */,
 				5D3A2F511C920CC20071F08F /* CGRect+VectorConvertible.swift in Sources */,
 				5D3A2F491C920CBC0071F08F /* DynamicFunctionType.swift in Sources */,
 				5D3A2F501C920CC20071F08F /* CGPoint+VectorConvertible.swift in Sources */,

--- a/Advance.xcodeproj/project.pbxproj
+++ b/Advance.xcodeproj/project.pbxproj
@@ -34,12 +34,12 @@
 		228E204B1C9CB99D0058ADA1 /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4631C876AD1000CF9EE /* Animatable.swift */; };
 		228E204C1C9CB99D0058ADA1 /* DisplayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3A2F5E1C922DAA0071F08F /* DisplayLink.swift */; };
 		228E204D1C9CB99D0058ADA1 /* BasicAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */; };
-		228E204E1C9CB99D0058ADA1 /* ValueAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimationType.swift */; };
+		228E204E1C9CB99D0058ADA1 /* ValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimation.swift */; };
 		228E204F1C9CB99D0058ADA1 /* CGSize+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4851C876AD1000CF9EE /* CGSize+VectorConvertible.swift */; };
 		228E20501C9CB99D0058ADA1 /* Spring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47F1C876AD1000CF9EE /* Spring.swift */; };
 		228E20511C9CB99D0058ADA1 /* Vector2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48C1C876AD1000CF9EE /* Vector2.swift */; };
 		228E20521C9CB99D0058ADA1 /* Vector4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48E1C876AD1000CF9EE /* Vector4.swift */; };
-		228E20531C9CB99D0058ADA1 /* AnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* AnimationType.swift */; };
+		228E20531C9CB99D0058ADA1 /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* Animation.swift */; };
 		228E20541C9CB99D0058ADA1 /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		228E20551C9CB99D0058ADA1 /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
 		228E20561C9CB99D0058ADA1 /* DecayFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */; };
@@ -87,9 +87,9 @@
 		5D3A2F3C1C920C7C0071F08F /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */; };
 		5D3A2F3D1C920C810071F08F /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		5D3A2F3E1C920C860071F08F /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
-		5D3A2F3F1C920C8C0071F08F /* AnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* AnimationType.swift */; };
+		5D3A2F3F1C920C8C0071F08F /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* Animation.swift */; };
 		5D3A2F401C920C8C0071F08F /* AnyValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */; };
-		5D3A2F411C920C8C0071F08F /* ValueAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimationType.swift */; };
+		5D3A2F411C920C8C0071F08F /* ValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimation.swift */; };
 		5D3A2F421C920C8C0071F08F /* Advanceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4651C876AD1000CF9EE /* Advanceable.swift */; };
 		5D3A2F431C920C920071F08F /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4721C876AD1000CF9EE /* Animator.swift */; };
 		5D3A2F441C920C920071F08F /* AnimatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4731C876AD1000CF9EE /* AnimatorContext.swift */; };
@@ -128,14 +128,14 @@
 		5DA94F4F1C8114680039B9BB /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA94F4E1C8114680039B9BB /* EventTests.swift */; };
 		5DB1A4911C876AD1000CF9EE /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4631C876AD1000CF9EE /* Animatable.swift */; };
 		5DB1A4921C876AD1000CF9EE /* Advanceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4651C876AD1000CF9EE /* Advanceable.swift */; };
-		5DB1A4931C876AD1000CF9EE /* AnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* AnimationType.swift */; };
+		5DB1A4931C876AD1000CF9EE /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4661C876AD1000CF9EE /* Animation.swift */; };
 		5DB1A4941C876AD1000CF9EE /* AnyValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */; };
 		5DB1A4951C876AD1000CF9EE /* BasicAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */; };
 		5DB1A4961C876AD1000CF9EE /* TimingFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */; };
 		5DB1A4971C876AD1000CF9EE /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */; };
 		5DB1A4981C876AD1000CF9EE /* DecayAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */; };
 		5DB1A4991C876AD1000CF9EE /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */; };
-		5DB1A49A1C876AD1000CF9EE /* ValueAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimationType.swift */; };
+		5DB1A49A1C876AD1000CF9EE /* ValueAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4701C876AD1000CF9EE /* ValueAnimation.swift */; };
 		5DB1A49B1C876AD1000CF9EE /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4721C876AD1000CF9EE /* Animator.swift */; };
 		5DB1A49C1C876AD1000CF9EE /* AnimatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4731C876AD1000CF9EE /* AnimatorContext.swift */; };
 		5DB1A49D1C876AD1000CF9EE /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4751C876AD1000CF9EE /* Event.swift */; };
@@ -332,14 +332,14 @@
 		5DA94F4E1C8114680039B9BB /* EventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		5DB1A4631C876AD1000CF9EE /* Animatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animatable.swift; sourceTree = "<group>"; };
 		5DB1A4651C876AD1000CF9EE /* Advanceable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Advanceable.swift; sourceTree = "<group>"; };
-		5DB1A4661C876AD1000CF9EE /* AnimationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationType.swift; sourceTree = "<group>"; };
+		5DB1A4661C876AD1000CF9EE /* Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyValueAnimation.swift; sourceTree = "<group>"; };
 		5DB1A4691C876AD1000CF9EE /* BasicAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAnimation.swift; sourceTree = "<group>"; };
 		5DB1A46A1C876AD1000CF9EE /* TimingFunctionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimingFunctionType.swift; sourceTree = "<group>"; };
 		5DB1A46B1C876AD1000CF9EE /* UnitBezier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitBezier.swift; sourceTree = "<group>"; };
 		5DB1A46D1C876AD1000CF9EE /* DecayAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecayAnimation.swift; sourceTree = "<group>"; };
 		5DB1A46F1C876AD1000CF9EE /* SpringAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringAnimation.swift; sourceTree = "<group>"; };
-		5DB1A4701C876AD1000CF9EE /* ValueAnimationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueAnimationType.swift; sourceTree = "<group>"; };
+		5DB1A4701C876AD1000CF9EE /* ValueAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueAnimation.swift; sourceTree = "<group>"; };
 		5DB1A4721C876AD1000CF9EE /* Animator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animator.swift; sourceTree = "<group>"; };
 		5DB1A4731C876AD1000CF9EE /* AnimatorContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatorContext.swift; sourceTree = "<group>"; };
 		5DB1A4751C876AD1000CF9EE /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -639,9 +639,9 @@
 				5DB1A4681C876AD1000CF9EE /* Basic */,
 				5DB1A46C1C876AD1000CF9EE /* Decay */,
 				5DB1A46E1C876AD1000CF9EE /* Spring */,
-				5DB1A4661C876AD1000CF9EE /* AnimationType.swift */,
+				5DB1A4661C876AD1000CF9EE /* Animation.swift */,
 				5DB1A4671C876AD1000CF9EE /* AnyValueAnimation.swift */,
-				5DB1A4701C876AD1000CF9EE /* ValueAnimationType.swift */,
+				5DB1A4701C876AD1000CF9EE /* ValueAnimation.swift */,
 				5DB1A4651C876AD1000CF9EE /* Advanceable.swift */,
 			);
 			path = Animation;
@@ -1118,12 +1118,12 @@
 				228E204B1C9CB99D0058ADA1 /* Animatable.swift in Sources */,
 				228E204C1C9CB99D0058ADA1 /* DisplayLink.swift in Sources */,
 				228E204D1C9CB99D0058ADA1 /* BasicAnimation.swift in Sources */,
-				228E204E1C9CB99D0058ADA1 /* ValueAnimationType.swift in Sources */,
+				228E204E1C9CB99D0058ADA1 /* ValueAnimation.swift in Sources */,
 				228E204F1C9CB99D0058ADA1 /* CGSize+VectorConvertible.swift in Sources */,
 				228E20501C9CB99D0058ADA1 /* Spring.swift in Sources */,
 				228E20511C9CB99D0058ADA1 /* Vector2.swift in Sources */,
 				228E20521C9CB99D0058ADA1 /* Vector4.swift in Sources */,
-				228E20531C9CB99D0058ADA1 /* AnimationType.swift in Sources */,
+				228E20531C9CB99D0058ADA1 /* Animation.swift in Sources */,
 				228E20541C9CB99D0058ADA1 /* DecayAnimation.swift in Sources */,
 				228E20551C9CB99D0058ADA1 /* SpringAnimation.swift in Sources */,
 				228E20561C9CB99D0058ADA1 /* DecayFunction.swift in Sources */,
@@ -1207,12 +1207,12 @@
 				5DB1A4911C876AD1000CF9EE /* Animatable.swift in Sources */,
 				5D3A2F5F1C922DAA0071F08F /* DisplayLink.swift in Sources */,
 				5DB1A4951C876AD1000CF9EE /* BasicAnimation.swift in Sources */,
-				5DB1A49A1C876AD1000CF9EE /* ValueAnimationType.swift in Sources */,
+				5DB1A49A1C876AD1000CF9EE /* ValueAnimation.swift in Sources */,
 				5DB1A4A91C876AD1000CF9EE /* CGSize+VectorConvertible.swift in Sources */,
 				5DB1A4A41C876AD1000CF9EE /* Spring.swift in Sources */,
 				5DB1A4AF1C876AD1000CF9EE /* Vector2.swift in Sources */,
 				5DB1A4B11C876AD1000CF9EE /* Vector4.swift in Sources */,
-				5DB1A4931C876AD1000CF9EE /* AnimationType.swift in Sources */,
+				5DB1A4931C876AD1000CF9EE /* Animation.swift in Sources */,
 				5DB1A4981C876AD1000CF9EE /* DecayAnimation.swift in Sources */,
 				5DB1A4991C876AD1000CF9EE /* SpringAnimation.swift in Sources */,
 				5DB1A4A11C876AD1000CF9EE /* DecayFunction.swift in Sources */,
@@ -1254,12 +1254,12 @@
 				5D3A2F471C920CB10071F08F /* Loop.swift in Sources */,
 				5D3A2F441C920C920071F08F /* AnimatorContext.swift in Sources */,
 				5D3A2F3C1C920C7C0071F08F /* UnitBezier.swift in Sources */,
-				5D3A2F411C920C8C0071F08F /* ValueAnimationType.swift in Sources */,
+				5D3A2F411C920C8C0071F08F /* ValueAnimation.swift in Sources */,
 				5D3A2F4C1C920CBC0071F08F /* SpringFunction.swift in Sources */,
 				5D3A2F391C920C710071F08F /* Animatable.swift in Sources */,
 				5D3A2F3A1C920C7C0071F08F /* BasicAnimation.swift in Sources */,
 				5D3A2F591C920CCA0071F08F /* VectorType.swift in Sources */,
-				5D3A2F3F1C920C8C0071F08F /* AnimationType.swift in Sources */,
+				5D3A2F3F1C920C8C0071F08F /* Animation.swift in Sources */,
 				5D3A2F4F1C920CC20071F08F /* CGFloat+VectorConvertible.swift in Sources */,
 				5D3A2F531C920CC20071F08F /* CGVector+VectorConvertible.swift in Sources */,
 				5D3A2F4B1C920CBC0071F08F /* Spring.swift in Sources */,

--- a/Advance.xcodeproj/project.pbxproj
+++ b/Advance.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		228E205B1C9CB99D0058ADA1 /* VectorMathCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48F1C876AD1000CF9EE /* VectorMathCapable.swift */; };
 		228E205C1C9CB99D0058ADA1 /* CGPoint+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4831C876AD1000CF9EE /* CGPoint+VectorConvertible.swift */; };
 		228E205D1C9CB99D0058ADA1 /* Vector1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A48B1C876AD1000CF9EE /* Vector1.swift */; };
-		228E205E1C9CB99D0058ADA1 /* DynamicFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunctionType.swift */; };
+		228E205E1C9CB99D0058ADA1 /* DynamicFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */; };
 		228E205F1C9CB99D0058ADA1 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4721C876AD1000CF9EE /* Animator.swift */; };
 		228E20601C9CB99D0058ADA1 /* DynamicSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */; };
 		228E20611C9CB99D0058ADA1 /* CGVector+VectorConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4861C876AD1000CF9EE /* CGVector+VectorConvertible.swift */; };
@@ -97,7 +97,7 @@
 		5D3A2F461C920C9C0071F08F /* CAMediaTimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4771C876AD1000CF9EE /* CAMediaTimingFunction.swift */; };
 		5D3A2F471C920CB10071F08F /* Loop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47A1C876AD1000CF9EE /* Loop.swift */; };
 		5D3A2F481C920CBC0071F08F /* DecayFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */; };
-		5D3A2F491C920CBC0071F08F /* DynamicFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunctionType.swift */; };
+		5D3A2F491C920CBC0071F08F /* DynamicFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */; };
 		5D3A2F4A1C920CBC0071F08F /* DynamicSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */; };
 		5D3A2F4B1C920CBC0071F08F /* Spring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47F1C876AD1000CF9EE /* Spring.swift */; };
 		5D3A2F4C1C920CBC0071F08F /* SpringFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4801C876AD1000CF9EE /* SpringFunction.swift */; };
@@ -142,7 +142,7 @@
 		5DB1A49E1C876AD1000CF9EE /* CAMediaTimingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4771C876AD1000CF9EE /* CAMediaTimingFunction.swift */; };
 		5DB1A4A01C876AD1000CF9EE /* Loop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47A1C876AD1000CF9EE /* Loop.swift */; };
 		5DB1A4A11C876AD1000CF9EE /* DecayFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */; };
-		5DB1A4A21C876AD1000CF9EE /* DynamicFunctionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunctionType.swift */; };
+		5DB1A4A21C876AD1000CF9EE /* DynamicFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */; };
 		5DB1A4A31C876AD1000CF9EE /* DynamicSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */; };
 		5DB1A4A41C876AD1000CF9EE /* Spring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A47F1C876AD1000CF9EE /* Spring.swift */; };
 		5DB1A4A51C876AD1000CF9EE /* SpringFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB1A4801C876AD1000CF9EE /* SpringFunction.swift */; };
@@ -346,7 +346,7 @@
 		5DB1A4771C876AD1000CF9EE /* CAMediaTimingFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CAMediaTimingFunction.swift; sourceTree = "<group>"; };
 		5DB1A47A1C876AD1000CF9EE /* Loop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loop.swift; sourceTree = "<group>"; };
 		5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecayFunction.swift; sourceTree = "<group>"; };
-		5DB1A47D1C876AD1000CF9EE /* DynamicFunctionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicFunctionType.swift; sourceTree = "<group>"; };
+		5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicFunction.swift; sourceTree = "<group>"; };
 		5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicSolver.swift; sourceTree = "<group>"; };
 		5DB1A47F1C876AD1000CF9EE /* Spring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spring.swift; sourceTree = "<group>"; };
 		5DB1A4801C876AD1000CF9EE /* SpringFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringFunction.swift; sourceTree = "<group>"; };
@@ -711,7 +711,7 @@
 			isa = PBXGroup;
 			children = (
 				5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */,
-				5DB1A47D1C876AD1000CF9EE /* DynamicFunctionType.swift */,
+				5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */,
 				5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */,
 				5DB1A47F1C876AD1000CF9EE /* Spring.swift */,
 				5DB1A4801C876AD1000CF9EE /* SpringFunction.swift */,
@@ -1134,7 +1134,7 @@
 				228E205B1C9CB99D0058ADA1 /* VectorMathCapable.swift in Sources */,
 				228E205C1C9CB99D0058ADA1 /* CGPoint+VectorConvertible.swift in Sources */,
 				228E205D1C9CB99D0058ADA1 /* Vector1.swift in Sources */,
-				228E205E1C9CB99D0058ADA1 /* DynamicFunctionType.swift in Sources */,
+				228E205E1C9CB99D0058ADA1 /* DynamicFunction.swift in Sources */,
 				228E205F1C9CB99D0058ADA1 /* Animator.swift in Sources */,
 				228E20601C9CB99D0058ADA1 /* DynamicSolver.swift in Sources */,
 				228E20611C9CB99D0058ADA1 /* CGVector+VectorConvertible.swift in Sources */,
@@ -1223,7 +1223,7 @@
 				5DB1A4B21C876AD1000CF9EE /* VectorMathCapable.swift in Sources */,
 				5DB1A4A71C876AD1000CF9EE /* CGPoint+VectorConvertible.swift in Sources */,
 				5DB1A4AE1C876AD1000CF9EE /* Vector1.swift in Sources */,
-				5DB1A4A21C876AD1000CF9EE /* DynamicFunctionType.swift in Sources */,
+				5DB1A4A21C876AD1000CF9EE /* DynamicFunction.swift in Sources */,
 				5DB1A49B1C876AD1000CF9EE /* Animator.swift in Sources */,
 				5DB1A4A31C876AD1000CF9EE /* DynamicSolver.swift in Sources */,
 				5DB1A4AA1C876AD1000CF9EE /* CGVector+VectorConvertible.swift in Sources */,
@@ -1274,7 +1274,7 @@
 				5D3A2F481C920CBC0071F08F /* DecayFunction.swift in Sources */,
 				5D3A2F3B1C920C7C0071F08F /* TimingFunction.swift in Sources */,
 				5D3A2F511C920CC20071F08F /* CGRect+VectorConvertible.swift in Sources */,
-				5D3A2F491C920CBC0071F08F /* DynamicFunctionType.swift in Sources */,
+				5D3A2F491C920CBC0071F08F /* DynamicFunction.swift in Sources */,
 				5D3A2F501C920CC20071F08F /* CGPoint+VectorConvertible.swift in Sources */,
 				5D3A2F581C920CCA0071F08F /* VectorMathCapable.swift in Sources */,
 				5D3A2F631C923ADB0071F08F /* DisplayLink.swift in Sources */,

--- a/Advance/Animatable/Animatable.swift
+++ b/Advance/Animatable/Animatable.swift
@@ -120,7 +120,7 @@ public final class Animatable<Value: VectorConvertible> {
     ///   animation has completed. Its only argument is a `Boolean`, which will 
     ///   be `true` if the animation completed uninterrupted, or `false` if it
     ///   was removed for any other reason.
-    public func animate<A: ValueAnimationType>(_ animation: A, completion: Completion? = nil) where A.Value == Value {
+    public func animate<A: ValueAnimation>(_ animation: A, completion: Completion? = nil) where A.Value == Value {
         
         // Cancel any in-flight animation. We observe the cancelled event of
         // animators that we create in order to clean up, so this will have

--- a/Advance/Animation/Animation.swift
+++ b/Advance/Animation/Animation.swift
@@ -26,18 +26,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-import Foundation
-
-/// Conforming types can be used to animate values conforming to `VectorConvertible`.
-public protocol ValueAnimationType: AnimationType {
+/// A protocol which defines the basic requirements to function as a
+/// time-advancable animation.
+public protocol Animation: Advanceable {
     
-    /// The type of value to be animated.
-    associatedtype Value: VectorConvertible
-    
-    /// The current value of the animation.
-    var value: Value { get }
-    
-    /// The current velocity of the animation.
-    var velocity: Value { get }
+    /// Returns `True` if the animation has completed. 
+    ///
+    /// After the animation finishes, it should not return to an unfinished 
+    /// state. Doing so may result in undefined behavior.
+    var finished: Bool { get }
     
 }
+

--- a/Advance/Animation/AnyValueAnimation.swift
+++ b/Advance/Animation/AnyValueAnimation.swift
@@ -27,10 +27,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
-/// Provides type erasure for an animation conforming to ValueAnimationType
+/// Provides type erasure for an animation conforming to ValueAnimation
 ///
 /// - parameter Value: The type of value to be animated.
-public struct AnyValueAnimation<Value: VectorConvertible>: ValueAnimationType {
+public struct AnyValueAnimation<Value: VectorConvertible>: ValueAnimation {
     
     /// The current value of the animation.
     public let value: Value
@@ -47,7 +47,7 @@ public struct AnyValueAnimation<Value: VectorConvertible>: ValueAnimationType {
     /// Creates a new type-erased animation.
     ///
     /// - parameter animation: The animation to be type erased.
-    public init<A: ValueAnimationType>(animation: A) where A.Value == Value {
+    public init<A: ValueAnimation>(animation: A) where A.Value == Value {
         value = animation.value
         velocity = animation.velocity
         finished = animation.finished

--- a/Advance/Animation/Basic/BasicAnimation.swift
+++ b/Advance/Animation/Basic/BasicAnimation.swift
@@ -42,7 +42,7 @@ public struct BasicAnimation<Value: VectorConvertible>: ValueAnimation {
     
     /// The timing function that is used to map elapsed time to an
     /// interpolated value.
-    fileprivate (set) public var timingFunction: TimingFunctionType
+    fileprivate (set) public var timingFunction: TimingFunction
     
     /// Creates a new `BasicAnimation` instance.
     ///
@@ -50,7 +50,7 @@ public struct BasicAnimation<Value: VectorConvertible>: ValueAnimation {
     /// - parameter to: The value at the end of the animation.
     /// - parameter duration: How long (in seconds) the animation should last.
     /// - parameter timingFunction: The timing function to use.
-    public init(from: Value, to: Value, duration: Double, timingFunction: TimingFunctionType = UnitBezier(preset: .swiftOut)) {
+    public init(from: Value, to: Value, duration: Double, timingFunction: TimingFunction = UnitBezier(preset: .swiftOut)) {
         self.from = from
         self.to = to
         self.duration = duration
@@ -113,7 +113,7 @@ public extension Animatable {
     /// - parameter timingFunction: The timing (easing) function to use.
     /// - parameter completion: An optional closure that will be called when
     ///   the animation completes.
-    public func animateTo(_ to: Value, duration: Double, timingFunction: TimingFunctionType, completion: Completion? = nil) {
+    public func animateTo(_ to: Value, duration: Double, timingFunction: TimingFunction, completion: Completion? = nil) {
         let a = BasicAnimation(from: value, to: to, duration: duration, timingFunction: timingFunction)
         animate(a, completion: completion)
     }
@@ -130,7 +130,7 @@ public extension VectorConvertible {
     /// - parameter callback: A closure that will be called with the new value
     ///   for each frame of the animation until it is finished.
     /// - returns: The underlying animator.
-    public func animateTo(_ to: Self, duration: Double, timingFunction: TimingFunctionType, callback: @escaping (Self)->Void) -> Animator<BasicAnimation<Self>> {
+    public func animateTo(_ to: Self, duration: Double, timingFunction: TimingFunction, callback: @escaping (Self)->Void) -> Animator<BasicAnimation<Self>> {
         let a = BasicAnimation(from: self, to: to, duration: duration, timingFunction: timingFunction)
         let animator = AnimatorContext.shared.animate(a)
         animator.changed.observe { (a) in

--- a/Advance/Animation/Basic/BasicAnimation.swift
+++ b/Advance/Animation/Basic/BasicAnimation.swift
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// Interpolates between values over a specified duration.
 ///
 /// - parameter Value: The type of value to be animated.
-public struct BasicAnimation<Value: VectorConvertible>: ValueAnimationType {
+public struct BasicAnimation<Value: VectorConvertible>: ValueAnimation {
     
     /// The initial value at time 0.
     fileprivate (set) public var from: Value

--- a/Advance/Animation/Basic/TimingFunction.swift
+++ b/Advance/Animation/Basic/TimingFunction.swift
@@ -30,7 +30,7 @@ import Foundation
 import CoreGraphics
 
 /// Conforming types can be used to convert linear input time (`0.0 -> 1.0`) to transformed output time (also `0.0 -> 1.0`).
-public protocol TimingFunctionType {
+public protocol TimingFunction {
     
     /// Transforms the given time.
     ///
@@ -41,7 +41,7 @@ public protocol TimingFunctionType {
 }
 
 /// Returns the input time, unmodified.
-public struct LinearTimingFunction: TimingFunctionType {
+public struct LinearTimingFunction: TimingFunction {
     
     /// Creates a new instance of `LinearTimingFunction`.
     public init(){}
@@ -53,7 +53,7 @@ public struct LinearTimingFunction: TimingFunctionType {
 }
 
 /// Output time is calculated as `(1.0-x)`.
-public struct ReversedTimingFunction: TimingFunctionType {
+public struct ReversedTimingFunction: TimingFunction {
     /// Creates a new instance of `ReversedTimingFunction`.
     public init(){}
     
@@ -64,7 +64,7 @@ public struct ReversedTimingFunction: TimingFunctionType {
 }
 
 
-extension UnitBezier: TimingFunctionType {
+extension UnitBezier: TimingFunction {
     
     /// Solves for time `x`.
     public func solveForTime(_ x: Scalar, epsilon: Scalar) -> Scalar {

--- a/Advance/Animation/Decay/DecayAnimation.swift
+++ b/Advance/Animation/Decay/DecayAnimation.swift
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// internally.
 public struct DecayAnimation<Value: VectorConvertible>: ValueAnimation {
     
-    fileprivate var solver: DynamicSolver<DecayFunction<Value.Vector>>
+    fileprivate var solver: DynamicSolver<DecayFunction<Value.VectorType>>
     
     /// Creates a new `DecayAnimation` instance.
     ///
@@ -42,7 +42,7 @@ public struct DecayAnimation<Value: VectorConvertible>: ValueAnimation {
     /// - parameter from: The initial value of the animation.
     /// - parameter velocity: The velocity at time `0`.
     public init(threshold: Scalar = 0.1, from: Value = Value.zero, velocity: Value = Value.zero) {
-        var f = DecayFunction<Value.Vector>()
+        var f = DecayFunction<Value.VectorType>()
         f.threshold = threshold
         f.drag = 3.0
         solver = DynamicSolver(function: f, value: from.vector, velocity: velocity.vector)

--- a/Advance/Animation/Decay/DecayAnimation.swift
+++ b/Advance/Animation/Decay/DecayAnimation.swift
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ///
 /// `DecayAnimation` uses a `DynamicSolver` containing a `DecayFunction`
 /// internally.
-public struct DecayAnimation<Value: VectorConvertible>: ValueAnimationType {
+public struct DecayAnimation<Value: VectorConvertible>: ValueAnimation {
     
     fileprivate var solver: DynamicSolver<DecayFunction<Value.Vector>>
     

--- a/Advance/Animation/Spring/SpringAnimation.swift
+++ b/Advance/Animation/Spring/SpringAnimation.swift
@@ -28,7 +28,7 @@
 
 
 /// The `SpringAnimation` struct is an implementation of
-/// `ValueAnimationType` that uses a configurable spring function to animate
+/// `ValueAnimation` that uses a configurable spring function to animate
 /// the value.
 ///
 /// Spring animations do not have a duration. Instead, you should configure
@@ -38,7 +38,7 @@
 ///
 /// SpringAnimation instances use a `DynamicSolver` containing a
 /// `SpringFunction` internally to perform the spring calculations.
-public struct SpringAnimation<Value: VectorConvertible>: ValueAnimationType {
+public struct SpringAnimation<Value: VectorConvertible>: ValueAnimation {
     
     // The underlying spring simulation.
     fileprivate var solver: DynamicSolver<SpringFunction<Value.Vector>>

--- a/Advance/Animation/Spring/SpringAnimation.swift
+++ b/Advance/Animation/Spring/SpringAnimation.swift
@@ -41,7 +41,7 @@
 public struct SpringAnimation<Value: VectorConvertible>: ValueAnimation {
     
     // The underlying spring simulation.
-    fileprivate var solver: DynamicSolver<SpringFunction<Value.Vector>>
+    fileprivate var solver: DynamicSolver<SpringFunction<Value.VectorType>>
     
     /// Creates a new `SpringAnimation` instance.
     ///

--- a/Advance/Animation/ValueAnimation.swift
+++ b/Advance/Animation/ValueAnimation.swift
@@ -26,15 +26,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-/// A protocol which defines the basic requirements to function as a
-/// time-advancable animation.
-public protocol AnimationType: Advanceable {
+import Foundation
+
+/// Conforming types can be used to animate values conforming to `VectorConvertible`.
+public protocol ValueAnimation: Animation {
     
-    /// Returns `True` if the animation has completed. 
-    ///
-    /// After the animation finishes, it should not return to an unfinished 
-    /// state. Doing so may result in undefined behavior.
-    var finished: Bool { get }
+    /// The type of value to be animated.
+    associatedtype Value: VectorConvertible
+    
+    /// The current value of the animation.
+    var value: Value { get }
+    
+    /// The current velocity of the animation.
+    var velocity: Value { get }
     
 }
-

--- a/Advance/Animator/Animator.swift
+++ b/Advance/Animator/Animator.swift
@@ -83,7 +83,7 @@ public enum AnimatorResult {
 /// `cancelled` or `finished` event, depending on the result. After entering
 /// the `Completed` state, the animator is finished and no further state changes
 /// can occur.
-public final class Animator<A: AnimationType> {
+public final class Animator<A: Animation> {
     
     fileprivate lazy var subscription: LoopSubscription? = {
         

--- a/Advance/Animator/AnimatorContext.swift
+++ b/Advance/Animator/AnimatorContext.swift
@@ -47,7 +47,7 @@ public final class AnimatorContext {
     ///
     /// - parameter animation: The animation to run.
     /// - returns: The newly generated `Animator` instance.
-    public func animate<A: AnimationType>(_ animation: A) -> Animator<A> {
+    public func animate<A: Animation>(_ animation: A) -> Animator<A> {
         let a = Animator(animation: animation)
         a.start()
         if a.state == .running {

--- a/Advance/Animator/AnimatorContext.swift
+++ b/Advance/Animator/AnimatorContext.swift
@@ -63,14 +63,14 @@ public final class AnimatorContext {
     }
 }
 
-private protocol AnimatorType: class {
+private protocol Cancelable: class {
     func cancel()
 }
 
-extension Animator: AnimatorType {}
+extension Animator: Cancelable {}
 
 private struct AnimatorWrapper: Hashable {
-    let animator: AnimatorType
+    let animator: Cancelable
     init<A>(animator: Animator<A>) {
         self.animator = animator
     }

--- a/Advance/Extensions/CAMediaTimingFunction.swift
+++ b/Advance/Extensions/CAMediaTimingFunction.swift
@@ -28,7 +28,7 @@
 
 import QuartzCore
 
-extension CAMediaTimingFunction: TimingFunctionType {
+extension CAMediaTimingFunction: TimingFunction {
     
     /// Solves for the given time with the specified precision.
     public func solveForTime(_ x: Scalar, epsilon: Scalar) -> Scalar {

--- a/Advance/Simulation/DecayFunction.swift
+++ b/Advance/Simulation/DecayFunction.swift
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /// Gradually reduces velocity until it equals `Vector.zero`.
-public struct DecayFunction<Vector: VectorType>: DynamicFunctionType {
+public struct DecayFunction<VectorType: Vector>: DynamicFunctionType {
     
     /// How close to 0 each component of the velocity must be before the
     /// simulation is allowed to settle.
@@ -40,19 +40,19 @@ public struct DecayFunction<Vector: VectorType>: DynamicFunctionType {
     public init() {}
     
     /// Calculates acceleration for a given state of the simulation.
-    public func acceleration(_ value: Vector, velocity: Vector) -> Vector {
+    public func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType {
         return -drag * velocity
     }
     
     /// Returns `true` if the simulation can become settled.
-    public func canSettle(_ value: Vector, velocity: Vector) -> Bool {
-        let min = Vector(scalar: -threshold)
-        let max = Vector(scalar: threshold)
+    public func canSettle(_ value: VectorType, velocity: VectorType) -> Bool {
+        let min = VectorType(scalar: -threshold)
+        let max = VectorType(scalar: threshold)
         return velocity.clamped(min: min, max: max) == velocity
     }
     
     /// Returns the value to settle on.
-    public func settledValue(_ value: Vector, velocity: Vector) -> Vector {
+    public func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType {
         return value
     }
 }

--- a/Advance/Simulation/DecayFunction.swift
+++ b/Advance/Simulation/DecayFunction.swift
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /// Gradually reduces velocity until it equals `Vector.zero`.
-public struct DecayFunction<VectorType: Vector>: DynamicFunctionType {
+public struct DecayFunction<VectorType: Vector>: DynamicFunction {
     
     /// How close to 0 each component of the velocity must be before the
     /// simulation is allowed to settle.

--- a/Advance/Simulation/DynamicFunction.swift
+++ b/Advance/Simulation/DynamicFunction.swift
@@ -28,7 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /// Conforming types implement a dynamic function that models changes to
 /// a vector over time.
-public protocol DynamicFunctionType {
+public protocol DynamicFunction {
     associatedtype VectorType: Vector
     
     /// The computed acceleration for a given simulation state.

--- a/Advance/Simulation/DynamicFunctionType.swift
+++ b/Advance/Simulation/DynamicFunctionType.swift
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// Conforming types implement a dynamic function that models changes to
 /// a vector over time.
 public protocol DynamicFunctionType {
-    associatedtype Vector: VectorType
+    associatedtype VectorType: Vector
     
     /// The computed acceleration for a given simulation state.
     ///
@@ -37,17 +37,17 @@ public protocol DynamicFunctionType {
     /// - parameter velocity: The current velocity of the simulation.
     /// - returns: A vector containing the acceleration (in units per second)
     ///   based on `value` and `velocity`.
-    func acceleration(_ value: Vector, velocity: Vector) -> Vector
+    func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType
     
     /// Returns `true` if the simulation should be allowed to enter its settled
     /// state. For example, a decay function may check that `velocity` is below
     /// a minimum threshold.
-    func canSettle(_ value: Vector, velocity: Vector) -> Bool
+    func canSettle(_ value: VectorType, velocity: VectorType) -> Bool
     
     /// Returns the value for the simulation as it enters the settled state.
     ///
     /// - parameter value: The current value of the simulation.
     /// - parameter velocity: The current velocity of the simulation.
     /// - returns: The value that the simulation will settle on.
-    func settledValue(_ value: Vector, velocity: Vector) -> Vector
+    func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType
 }

--- a/Advance/Simulation/DynamicSolver.swift
+++ b/Advance/Simulation/DynamicSolver.swift
@@ -70,18 +70,18 @@ public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
     fileprivate (set) public var settled: Bool = false
     
     // The current state of the solver.
-    fileprivate var simulationState: DynamicSolverState<F.Vector>
+    fileprivate var simulationState: DynamicSolverState<F.VectorType>
     
     // The latest interpolated state that we use to return values to the outside
     // world.
-    fileprivate var interpolatedState: DynamicSolverState<F.Vector>
+    fileprivate var interpolatedState: DynamicSolverState<F.VectorType>
     
     /// Creates a new `DynamicSolver` instance.
     ///
     /// - parameter function: The function that will drive the simulation.
     /// - parameter value: The initial value of the simulation.
     /// - parameter velocity: The initial velocity of the simulation.
-    public init(function: F, value: F.Vector, velocity: F.Vector = F.Vector.zero) {
+    public init(function: F, value: F.VectorType, velocity: F.VectorType = F.VectorType.zero) {
         self.function = function
         simulationState = DynamicSolverState(value: value, velocity: velocity)
         interpolatedState = simulationState
@@ -92,7 +92,7 @@ public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
         guard settled == false else { return }
         if function.canSettle(simulationState.value, velocity: simulationState.velocity) {
             simulationState.value = function.settledValue(simulationState.value, velocity: simulationState.velocity)
-            simulationState.velocity = F.Vector.zero
+            simulationState.velocity = F.VectorType.zero
             interpolatedState = simulationState
             settled = true
         }
@@ -148,7 +148,7 @@ public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
     }
     
     /// The current value.
-    public var value: F.Vector {
+    public var value: F.VectorType {
         get { return interpolatedState.value }
         set {
             interpolatedState.value = newValue
@@ -159,7 +159,7 @@ public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
     }
     
     /// The current velocity.
-    public var velocity: F.Vector {
+    public var velocity: F.VectorType {
         get { return interpolatedState.velocity }
         set {
             interpolatedState.velocity = newValue
@@ -170,21 +170,21 @@ public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
     }
 }
 
-private struct DynamicSolverState<Vector: VectorType> {
-    var value: Vector
-    var velocity: Vector
-    init(value: Vector, velocity: Vector) {
+private struct DynamicSolverState<VectorType: Vector> {
+    var value: VectorType
+    var velocity: VectorType
+    init(value: VectorType, velocity: VectorType) {
         self.value = value
         self.velocity = velocity
     }
 }
 
 private extension DynamicSolverState {
-    typealias Derivative = DynamicSolverState<Vector>
+    typealias Derivative = DynamicSolverState<VectorType>
     
     /// RK4 Integration.
-    func integrate<F: DynamicFunctionType>(_ function: F, time: Double) -> DynamicSolverState<Vector> where F.Vector == Vector {
-        let initial = Derivative(value:Vector.zero, velocity: Vector.zero)
+    func integrate<F: DynamicFunctionType>(_ function: F, time: Double) -> DynamicSolverState<VectorType> where F.VectorType == VectorType {
+        let initial = Derivative(value:VectorType.zero, velocity: VectorType.zero)
         
         let a = evaluate(function, time: 0.0, derivative: initial)
         let b = evaluate(function, time: time * 0.5, derivative: a)
@@ -206,7 +206,7 @@ private extension DynamicSolverState {
         return DynamicSolverState(value: val, velocity: vel)
     }
     
-    func evaluate<F: DynamicFunctionType>(_ function: F, time: Double, derivative: Derivative) -> Derivative where F.Vector == Vector {
+    func evaluate<F: DynamicFunctionType>(_ function: F, time: Double, derivative: Derivative) -> Derivative where F.VectorType == VectorType {
         let val = value + Scalar(time) * derivative.value
         let vel = velocity + Scalar(time) * derivative.velocity
         let accel = function.acceleration(val, velocity: vel)

--- a/Advance/Simulation/DynamicSolver.swift
+++ b/Advance/Simulation/DynamicSolver.swift
@@ -44,7 +44,7 @@ import Foundation
 /// up" to the outside time. It then uses linear interpolation to match the
 /// internal state to the required external time in order to return the most
 /// precise calculations.
-public struct DynamicSolver<F: DynamicFunctionType> : Advanceable {
+public struct DynamicSolver<F: DynamicFunction> : Advanceable {
     
     // The internal time step. 0.008 == 120fps (double the typical screen refresh
     // rate). The math required to solve most functions is easy for modern
@@ -183,7 +183,7 @@ private extension DynamicSolverState {
     typealias Derivative = DynamicSolverState<VectorType>
     
     /// RK4 Integration.
-    func integrate<F: DynamicFunctionType>(_ function: F, time: Double) -> DynamicSolverState<VectorType> where F.VectorType == VectorType {
+    func integrate<F: DynamicFunction>(_ function: F, time: Double) -> DynamicSolverState<VectorType> where F.VectorType == VectorType {
         let initial = Derivative(value:VectorType.zero, velocity: VectorType.zero)
         
         let a = evaluate(function, time: 0.0, derivative: initial)
@@ -206,7 +206,7 @@ private extension DynamicSolverState {
         return DynamicSolverState(value: val, velocity: vel)
     }
     
-    func evaluate<F: DynamicFunctionType>(_ function: F, time: Double, derivative: Derivative) -> Derivative where F.VectorType == VectorType {
+    func evaluate<F: DynamicFunction>(_ function: F, time: Double, derivative: Derivative) -> Derivative where F.VectorType == VectorType {
         let val = value + Scalar(time) * derivative.value
         let vel = velocity + Scalar(time) * derivative.velocity
         let accel = function.acceleration(val, velocity: vel)

--- a/Advance/Simulation/Spring.swift
+++ b/Advance/Simulation/Spring.swift
@@ -46,11 +46,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// s.target = CGPoint(x: 100.0, y: 200.0)
 /// // Off it goes!
 /// ```
-public final class Spring<T: VectorConvertible> {
+public final class Spring<Value: VectorConvertible> {
     
-    fileprivate var solver: DynamicSolver<SpringFunction<T.Vector>> {
+    fileprivate var solver: DynamicSolver<SpringFunction<Value.VectorType>> {
         didSet {
-            lastNotifiedValue = T(vector: solver.value)
+            lastNotifiedValue = Value(vector: solver.value)
             if solver.settled == false && subscription.paused == true {
                 subscription.paused = false
             }
@@ -71,9 +71,9 @@ public final class Spring<T: VectorConvertible> {
     }()
     
     /// Fires when `value` has changed.
-    public let changed = Event<T>()
+    public let changed = Event<Value>()
     
-    fileprivate var lastNotifiedValue: T {
+    fileprivate var lastNotifiedValue: Value {
         didSet {
             guard lastNotifiedValue != oldValue else { return }
             changed.fire(lastNotifiedValue)
@@ -85,14 +85,14 @@ public final class Spring<T: VectorConvertible> {
     /// - parameter value: The initial value of the spring. The spring will be
     ///   initialized with `target` and `value` equal to the given value, and
     ///   a velocity of `0`.
-    public init(value: T) {
+    public init(value: Value) {
         let f = SpringFunction(target: value.vector)
         solver = DynamicSolver(function: f, value: value.vector)
         lastNotifiedValue = value
     }
     
     /// Removes any current velocity and snaps the spring directly to the given value.
-    public func reset(_ value: T) {
+    public func reset(_ value: Value) {
         var f = solver.function
         f.target = value.vector
         solver = DynamicSolver(function: f, value: value.vector)
@@ -100,21 +100,21 @@ public final class Spring<T: VectorConvertible> {
     }
     
     /// The current value of the spring.
-    public var value: T {
-        get { return T(vector: solver.value) }
+    public var value: Value {
+        get { return Value(vector: solver.value) }
         set { solver.value = newValue.vector }
     }
     
     /// The current velocity of the simulation.
-    public var velocity: T {
-        get { return T(vector: solver.velocity) }
+    public var velocity: Value {
+        get { return Value(vector: solver.velocity) }
         set { solver.velocity = newValue.vector }
     }
     
     /// The target value of the spring. As the simulation runs, `value` will be 
     /// pulled toward this value.
-    public var target: T {
-        get { return T(vector: solver.function.target) }
+    public var target: Value {
+        get { return Value(vector: solver.function.target) }
         set { solver.function.target = newValue.vector }
     }
     

--- a/Advance/Simulation/SpringFunction.swift
+++ b/Advance/Simulation/SpringFunction.swift
@@ -46,7 +46,7 @@ public struct SpringConfiguration {
 }
 
 /// Implements a simple spring acceleration function.
-public struct SpringFunction<VectorType: Vector>: DynamicFunctionType {
+public struct SpringFunction<VectorType: Vector>: DynamicFunction {
     
     /// The target of the spring.
     public var target: VectorType

--- a/Advance/Simulation/SpringFunction.swift
+++ b/Advance/Simulation/SpringFunction.swift
@@ -46,10 +46,10 @@ public struct SpringConfiguration {
 }
 
 /// Implements a simple spring acceleration function.
-public struct SpringFunction<T: VectorType>: DynamicFunctionType {
+public struct SpringFunction<VectorType: Vector>: DynamicFunctionType {
     
     /// The target of the spring.
-    public var target: T
+    public var target: VectorType
     
     /// Configuration options.
     public var configuration: SpringConfiguration
@@ -57,22 +57,22 @@ public struct SpringFunction<T: VectorType>: DynamicFunctionType {
     /// Creates a new `SpringFunction` instance.
     ///
     /// - parameter target: The target of the new instance.
-    public init(target: T) {
+    public init(target: VectorType) {
         self.target = target
         self.configuration = SpringConfiguration()
     }
     
     /// Calculates acceleration for a given state of the simulation.
-    public func acceleration(_ value: T, velocity: T) -> T {
+    public func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType {
         let delta = value - target
         let accel = (-configuration.tension * delta) - (configuration.damping * velocity)
         return accel
     }
     
     /// Returns `true` if the simulation can become settled.
-    public func canSettle(_ value: T, velocity: T) -> Bool {
-        let min = Vector(scalar: -configuration.threshold)
-        let max = Vector(scalar: configuration.threshold)
+    public func canSettle(_ value: VectorType, velocity: VectorType) -> Bool {
+        let min = VectorType(scalar: -configuration.threshold)
+        let max = VectorType(scalar: configuration.threshold)
         
         if velocity.clamped(min: min, max: max) != velocity {
             return false
@@ -87,7 +87,7 @@ public struct SpringFunction<T: VectorType>: DynamicFunctionType {
     }
     
     /// Returns the value to settle on.
-    public func settledValue(_ value: T, velocity: T) -> T {
+    public func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType {
         return target
     }
 }

--- a/Advance/VectorConvertible/VectorConvertible.swift
+++ b/Advance/VectorConvertible/VectorConvertible.swift
@@ -31,20 +31,20 @@ public protocol VectorConvertible: Equatable, Interpolatable {
     
     /// The concrete VectorType implementation that can represent the 
     /// conforming type.
-    associatedtype Vector: VectorType
+    associatedtype VectorType: Vector
     
     /// Creates a new instance from a vector.
-    init(vector: Vector)
+    init(vector: VectorType)
     
     /// The vector representation of this instance.
-    var vector: Vector { get }
+    var vector: VectorType { get }
 }
 
 public extension VectorConvertible {
     
     /// Returns an instance initialized using the zero vector.
     public static var zero: Self {
-        return Self(vector: Vector.zero)
+        return Self(vector: VectorType.zero)
     }
 }
 

--- a/Advance/Vectors/Vector.swift
+++ b/Advance/Vectors/Vector.swift
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 public typealias Scalar = Double
 
 /// Conforming types can be operated on as vectors composed of `Scalar` components.
-public protocol VectorType: Equatable, Interpolatable, VectorMathCapable {
+public protocol Vector: Equatable, Interpolatable, VectorMathCapable {
     
     /// Creates a vector for which all components are equal to the given scalar.
     init(scalar: Scalar)
@@ -59,7 +59,7 @@ public protocol VectorType: Equatable, Interpolatable, VectorMathCapable {
 }
 
 
-public extension VectorType {
+public extension Vector {
     
     /// Returns a vector where each component is clamped by the corresponding
     /// components in `min` and `max`.

--- a/Advance/Vectors/Vector1.swift
+++ b/Advance/Vectors/Vector1.swift
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// A vector with 1 component.
 public typealias Vector1 = Scalar
 
-extension Vector1: VectorType {
+extension Vector1: Vector {
     
     /// Creates a vector for which all components are equal to the given scalar.
     public init(scalar: Scalar) {

--- a/Advance/Vectors/Vector2.swift
+++ b/Advance/Vectors/Vector2.swift
@@ -42,7 +42,7 @@ public struct Vector2 {
     }
 }
 
-extension Vector2: VectorType {
+extension Vector2: Vector {
     
     /// Creates a vector for which all components are equal to the given scalar.
     public init(scalar: Scalar) {

--- a/Advance/Vectors/Vector3.swift
+++ b/Advance/Vectors/Vector3.swift
@@ -46,7 +46,7 @@ public struct Vector3 {
     }
 }
 
-extension Vector3: VectorType {
+extension Vector3: Vector {
     
     /// Creates a vector for which all components are equal to the given scalar.
     public init(scalar: Scalar) {

--- a/Advance/Vectors/Vector4.swift
+++ b/Advance/Vectors/Vector4.swift
@@ -50,7 +50,7 @@ public struct Vector4 {
     }
 }
 
-extension Vector4: VectorType {
+extension Vector4: Vector {
     
     /// Creates a vector for which all components are equal to the given scalar.
     public init(scalar: Scalar) {

--- a/AdvanceSample-iOS/GravityFunction.swift
+++ b/AdvanceSample-iOS/GravityFunction.swift
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import Advance
 import Foundation
 
-struct GravityFunction: DynamicFunctionType {
+struct GravityFunction: DynamicFunction {
     
     typealias Vector = Vector2
     

--- a/AdvanceTests-iOS/VectorTests.swift
+++ b/AdvanceTests-iOS/VectorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Advance
 
 
-class VectorTypeTests: XCTestCase {
+class VectorTests: XCTestCase {
     func testVector1() {
         XCTAssert(Vector1.length == 1)
         VectorTester<Vector1>.runTests()
@@ -25,7 +25,7 @@ class VectorTypeTests: XCTestCase {
 }
 
 
-struct VectorTester<T: VectorType> {
+struct VectorTester<T: Vector> {
     static func runTests() {
         testScalarInit()
         testZero()


### PR DESCRIPTION
Naming conventions in Swift have changed since the 2.x days – this renames several core protocols to remove `...Type` suffixes (e.g. `VectorType` -> `Vector`).