### PR TITLE
Broke DynamicState out into a new file and made it public

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -45,6 +45,7 @@ custom_categories:
     - DecayFunction
     - DynamicSolver
     - DynamicFunctionType
+    - DynamicState
     - Spring
     - SpringFunction
     - SpringConfiguration

--- a/Advance.xcodeproj/project.pbxproj
+++ b/Advance.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		222E21231C7E448D0063FAA2 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E21221C7E448D0063FAA2 /* DemoViewController.swift */; };
 		222E21251C7E45420063FAA2 /* BrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E21241C7E45420063FAA2 /* BrowserView.swift */; };
 		22319B721C8110A300D4E027 /* CoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22319B711C8110A300D4E027 /* CoverView.swift */; };
+		2239A2A51FFB1B0D0046E89E /* DynamicState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2239A2A41FFB1B0D0046E89E /* DynamicState.swift */; };
+		2239A2A61FFB1B0D0046E89E /* DynamicState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2239A2A41FFB1B0D0046E89E /* DynamicState.swift */; };
+		2239A2A71FFB1B0D0046E89E /* DynamicState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2239A2A41FFB1B0D0046E89E /* DynamicState.swift */; };
 		223E49731C76C9430048CAB6 /* SpringsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E49721C76C9430048CAB6 /* SpringsViewController.swift */; };
 		223E49751C76C9510048CAB6 /* SpringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E49741C76C9510048CAB6 /* SpringView.swift */; };
 		226A752C1C84153E00A7F1FB /* GravitySimulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226A752B1C84153E00A7F1FB /* GravitySimulation.swift */; };
@@ -291,6 +294,7 @@
 		222E21221C7E448D0063FAA2 /* DemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoViewController.swift; sourceTree = "<group>"; };
 		222E21241C7E45420063FAA2 /* BrowserView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserView.swift; sourceTree = "<group>"; };
 		22319B711C8110A300D4E027 /* CoverView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverView.swift; sourceTree = "<group>"; };
+		2239A2A41FFB1B0D0046E89E /* DynamicState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicState.swift; sourceTree = "<group>"; };
 		223E49721C76C9430048CAB6 /* SpringsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringsViewController.swift; sourceTree = "<group>"; };
 		223E49741C76C9510048CAB6 /* SpringView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringView.swift; sourceTree = "<group>"; };
 		226A752B1C84153E00A7F1FB /* GravitySimulation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravitySimulation.swift; sourceTree = "<group>"; };
@@ -713,6 +717,7 @@
 				5DB1A47C1C876AD1000CF9EE /* DecayFunction.swift */,
 				5DB1A47D1C876AD1000CF9EE /* DynamicFunction.swift */,
 				5DB1A47E1C876AD1000CF9EE /* DynamicSolver.swift */,
+				2239A2A41FFB1B0D0046E89E /* DynamicState.swift */,
 				5DB1A47F1C876AD1000CF9EE /* Spring.swift */,
 				5DB1A4801C876AD1000CF9EE /* SpringFunction.swift */,
 			);
@@ -1131,6 +1136,7 @@
 				228E20581C9CB99D0058ADA1 /* Double+VectorConvertible.swift in Sources */,
 				228E20591C9CB99D0058ADA1 /* AnyValueAnimation.swift in Sources */,
 				228E205A1C9CB99D0058ADA1 /* CGRect+VectorConvertible.swift in Sources */,
+				2239A2A61FFB1B0D0046E89E /* DynamicState.swift in Sources */,
 				228E205B1C9CB99D0058ADA1 /* VectorMathCapable.swift in Sources */,
 				228E205C1C9CB99D0058ADA1 /* CGPoint+VectorConvertible.swift in Sources */,
 				228E205D1C9CB99D0058ADA1 /* Vector1.swift in Sources */,
@@ -1220,6 +1226,7 @@
 				5DB1A4AB1C876AD1000CF9EE /* Double+VectorConvertible.swift in Sources */,
 				5DB1A4941C876AD1000CF9EE /* AnyValueAnimation.swift in Sources */,
 				5DB1A4A81C876AD1000CF9EE /* CGRect+VectorConvertible.swift in Sources */,
+				2239A2A51FFB1B0D0046E89E /* DynamicState.swift in Sources */,
 				5DB1A4B21C876AD1000CF9EE /* VectorMathCapable.swift in Sources */,
 				5DB1A4A71C876AD1000CF9EE /* CGPoint+VectorConvertible.swift in Sources */,
 				5DB1A4AE1C876AD1000CF9EE /* Vector1.swift in Sources */,
@@ -1276,6 +1283,7 @@
 				5D3A2F511C920CC20071F08F /* CGRect+VectorConvertible.swift in Sources */,
 				5D3A2F491C920CBC0071F08F /* DynamicFunction.swift in Sources */,
 				5D3A2F501C920CC20071F08F /* CGPoint+VectorConvertible.swift in Sources */,
+				2239A2A71FFB1B0D0046E89E /* DynamicState.swift in Sources */,
 				5D3A2F581C920CCA0071F08F /* VectorMathCapable.swift in Sources */,
 				5D3A2F631C923ADB0071F08F /* DisplayLink.swift in Sources */,
 				5D3A2F4D1C920CC20071F08F /* VectorConvertible.swift in Sources */,

--- a/Advance/Simulation/DecayFunction.swift
+++ b/Advance/Simulation/DecayFunction.swift
@@ -40,19 +40,19 @@ public struct DecayFunction<VectorType: Vector>: DynamicFunction {
     public init() {}
     
     /// Calculates acceleration for a given state of the simulation.
-    public func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType {
-        return -drag * velocity
+    public func acceleration(state: DynamicState<VectorType>) -> VectorType {
+        return -drag * state.velocity
     }
     
     /// Returns `true` if the simulation can become settled.
-    public func canSettle(_ value: VectorType, velocity: VectorType) -> Bool {
+    public func canSettle(state: DynamicState<VectorType>) -> Bool {
         let min = VectorType(scalar: -threshold)
         let max = VectorType(scalar: threshold)
-        return velocity.clamped(min: min, max: max) == velocity
+        return state.velocity.clamped(min: min, max: max) == state.velocity
     }
     
     /// Returns the value to settle on.
-    public func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType {
-        return value
+    public func settledValue(state: DynamicState<VectorType>) -> VectorType {
+        return state.value
     }
 }

--- a/Advance/Simulation/DynamicFunction.swift
+++ b/Advance/Simulation/DynamicFunction.swift
@@ -33,21 +33,19 @@ public protocol DynamicFunction {
     
     /// The computed acceleration for a given simulation state.
     ///
-    /// - parameter value: The current value of the simulation.
-    /// - parameter velocity: The current velocity of the simulation.
+    /// - parameter state: The current state of the simulation.
     /// - returns: A vector containing the acceleration (in units per second)
     ///   based on `value` and `velocity`.
-    func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType
+    func acceleration(state: DynamicState<VectorType>) -> VectorType
     
     /// Returns `true` if the simulation should be allowed to enter its settled
     /// state. For example, a decay function may check that `velocity` is below
     /// a minimum threshold.
-    func canSettle(_ value: VectorType, velocity: VectorType) -> Bool
+    func canSettle(state: DynamicState<VectorType>) -> Bool
     
     /// Returns the value for the simulation as it enters the settled state.
     ///
-    /// - parameter value: The current value of the simulation.
-    /// - parameter velocity: The current velocity of the simulation.
+    /// - parameter state: The current state of the simulation.
     /// - returns: The value that the simulation will settle on.
-    func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType
+    func settledValue(state: DynamicState<VectorType>) -> VectorType
 }

--- a/Advance/Simulation/DynamicState.swift
+++ b/Advance/Simulation/DynamicState.swift
@@ -1,0 +1,81 @@
+/*
+ 
+ Copyright (c) 2016, Storehouse Media Inc.
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ * Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ */
+
+import Foundation
+
+
+public struct DynamicState<VectorType: Vector> {
+    
+    public var value: VectorType
+    
+    public var velocity: VectorType
+    
+    public init(value: VectorType, velocity: VectorType) {
+        self.value = value
+        self.velocity = velocity
+    }
+    
+}
+
+extension DynamicState {
+    
+    /// RK4 Integration.
+    public func integrate<F: DynamicFunction>(_ function: F, time: Double) -> DynamicState<VectorType> where F.VectorType == VectorType {
+        
+        let initial = Derivative(value:VectorType.zero, velocity: VectorType.zero)
+        
+        let a = evaluate(function, time: 0.0, derivative: initial)
+        let b = evaluate(function, time: time * 0.5, derivative: a)
+        let c = evaluate(function, time: time * 0.5, derivative: b)
+        let d = evaluate(function, time: time, derivative: c)
+        
+        var dxdt = a.value
+        dxdt += (2.0 * (b.value + c.value)) + d.value
+        dxdt = Scalar(1.0/6.0) * dxdt
+        
+        var dvdt = a.velocity
+        dvdt += (2.0 * (b.velocity + c.velocity)) + d.velocity
+        dvdt = Scalar(1.0/6.0) * dvdt
+        
+        
+        let val = value + Scalar(time) * dxdt
+        let vel = velocity + Scalar(time) * dvdt
+        
+        return DynamicState(value: val, velocity: vel)
+    }
+    
+    private typealias Derivative = DynamicState<VectorType>
+    
+    private func evaluate<F: DynamicFunction>(_ function: F, time: Double, derivative: Derivative) -> Derivative where F.VectorType == VectorType {
+        let val = value + Scalar(time) * derivative.value
+        let vel = velocity + Scalar(time) * derivative.velocity
+        let accel = function.acceleration(state: DynamicState(value: val, velocity: vel))
+        let d = Derivative(value: vel, velocity: accel)
+        return d
+    }
+}

--- a/Advance/Simulation/SpringFunction.swift
+++ b/Advance/Simulation/SpringFunction.swift
@@ -63,22 +63,22 @@ public struct SpringFunction<VectorType: Vector>: DynamicFunction {
     }
     
     /// Calculates acceleration for a given state of the simulation.
-    public func acceleration(_ value: VectorType, velocity: VectorType) -> VectorType {
-        let delta = value - target
-        let accel = (-configuration.tension * delta) - (configuration.damping * velocity)
+    public func acceleration(state: DynamicState<VectorType>) -> VectorType {
+        let delta = state.value - target
+        let accel = (-configuration.tension * delta) - (configuration.damping * state.velocity)
         return accel
     }
     
     /// Returns `true` if the simulation can become settled.
-    public func canSettle(_ value: VectorType, velocity: VectorType) -> Bool {
+    public func canSettle(state: DynamicState<VectorType>) -> Bool {
         let min = VectorType(scalar: -configuration.threshold)
         let max = VectorType(scalar: configuration.threshold)
         
-        if velocity.clamped(min: min, max: max) != velocity {
+        if state.velocity.clamped(min: min, max: max) != state.velocity {
             return false
         }
         
-        let valueDelta = value - target
+        let valueDelta = state.value - target
         if valueDelta.clamped(min: min, max: max) != valueDelta {
             return false
         }
@@ -87,7 +87,7 @@ public struct SpringFunction<VectorType: Vector>: DynamicFunction {
     }
     
     /// Returns the value to settle on.
-    public func settledValue(_ value: VectorType, velocity: VectorType) -> VectorType {
+    public func settledValue(state: DynamicState<VectorType>) -> VectorType {
         return target
     }
 }

--- a/AdvanceSample-iOS/GravityFunction.swift
+++ b/AdvanceSample-iOS/GravityFunction.swift
@@ -31,21 +31,21 @@ import Foundation
 
 struct GravityFunction: DynamicFunction {
     
-    typealias Vector = Vector2
+    typealias VectorType = Vector2
     
-    var target: Vector
+    var target: VectorType
     
     var minRadius = 30.0
     
     var threshold: Scalar = 0.1
     
-    init(target: Vector) {
+    init(target: VectorType) {
         self.target = target
     }
     
-    func acceleration(_ value: Vector, velocity: Vector) -> Vector {
+    func acceleration(state: DynamicState<VectorType>) -> VectorType {
         
-        let delta = target - value
+        let delta = target - state.value
         let heading = atan2(delta.y, delta.x)
         
         var distance = hypot(delta.x, delta.y)
@@ -53,21 +53,21 @@ struct GravityFunction: DynamicFunction {
         
         let accel = 1000000.0 / (distance*distance)
         
-        var result = Vector.zero
+        var result = VectorType.zero
         result.x = accel * cos(heading)
         result.y = accel * sin(heading)
         return result
     }
     
-    func canSettle(_ value: Vector, velocity: Vector) -> Bool {
-        let min = Vector(scalar: -threshold)
-        let max = Vector(scalar: threshold)
+    func canSettle(state: DynamicState<VectorType>) -> Bool {
+        let min = VectorType(scalar: -threshold)
+        let max = VectorType(scalar: threshold)
         
-        if velocity.clamped(min: min, max: max) != velocity {
+        if state.velocity.clamped(min: min, max: max) != state.velocity {
             return false
         }
         
-        let valueDelta = value - target
+        let valueDelta = state.value - target
         if valueDelta.clamped(min: min, max: max) != valueDelta {
             return false
         }
@@ -75,7 +75,7 @@ struct GravityFunction: DynamicFunction {
         return true
     }
     
-    func settledValue(_ value: Vector, velocity: Vector) -> Vector {
+    func settledValue(state: DynamicState<VectorType>) -> VectorType {
         return target
     }
 }


### PR DESCRIPTION
This is rework for a solver refactor / cleanup pass.

`State` was intended to be a subtype of `DynamicSolver<F>`, but the Swift runtime is choking on a cyclic metadata bug 🙄. This will do for now.